### PR TITLE
Fix supabase import paths

### DIFF
--- a/aiService.ts
+++ b/aiService.ts
@@ -1,4 +1,4 @@
-import { supabase } from '../lib/supabase';
+import { supabase } from './supabase';
 
 export interface ChatMessage {
   message: string;

--- a/useAuth.ts
+++ b/useAuth.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { User as SupabaseUser } from '@supabase/supabase-js';
-import { supabase } from '../lib/supabase';
+import { supabase } from './supabase';
 import { User } from '../types';
 
 export function useAuth() {

--- a/useFlows.ts
+++ b/useFlows.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { supabase } from '../lib/supabase';
+import { supabase } from './supabase';
 import { Prompt } from '../types';
 
 interface Flow {


### PR DESCRIPTION
## Summary
- fix imports for supabase client in hooks and API service

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685815a4e484832ab20cdb171eb45394