### PR TITLE
Add shared type definitions

### DIFF
--- a/AccountScreen.tsx
+++ b/AccountScreen.tsx
@@ -4,7 +4,7 @@ import { Input } from '../components/ui/Input';
 import { Card, CardHeader, CardContent, CardFooter } from '../components/ui/Card';
 import { Badge } from '../components/ui/Badge';
 import { ArrowLeft, User, Crown, Zap, CreditCard, Check, Settings, BarChart3, Sparkles, Shield, Clock, TrendingUp, Award, Target, Rocket, Star, CheckCircle, AlertCircle, Calendar, Mail, Briefcase, Edit3, Save, X } from 'lucide-react';
-import { User as UserType } from '../types';
+import { User as UserType } from '../src/types';
 
 interface AccountScreenProps {
   user: UserType;

--- a/App.tsx
+++ b/App.tsx
@@ -9,7 +9,7 @@ import { CommunityScreen } from './screens/CommunityScreen';
 import { AccountScreen } from './screens/AccountScreen';
 import { ChatScreen } from './screens/ChatScreen';
 import { AuthModal } from './components/auth/AuthModal';
-import { AppState, JobDetection, Prompt } from './types';
+import { AppState, JobDetection, Prompt } from './src/types';
 import { useAuth } from './hooks/useAuth';
 
 interface OnboardingData {

--- a/ChatScreen.tsx
+++ b/ChatScreen.tsx
@@ -3,7 +3,7 @@ import { Button } from '../components/ui/Button';
 import { Card, CardHeader, CardContent } from '../components/ui/Card';
 import { Badge } from '../components/ui/Badge';
 import { ArrowLeft, Send, Mic, MicOff, Copy, Download, FileText, Save, Star, Plus, Sparkles, Bot, User, Crown, Zap, MessageSquare, Folder, ChevronRight, Search, Filter, Play, Pause, Volume2, MoreHorizontal, Trash2, Edit3, Share2, BookOpen, Target, Shield, Rocket, BarChart3, Users, Mail, Calendar, Briefcase, Settings, Clock, CheckCircle, AlertCircle, Loader, ChevronLeft, Grid3X3, List, SlidersHorizontal, Workflow, Layers, Database, Command, Maximize2, Minimize2 } from 'lucide-react';
-import { User as UserType } from '../types';
+import { User as UserType } from '../src/types';
 
 interface ChatScreenProps {
   user: UserType;

--- a/CommunityScreen.tsx
+++ b/CommunityScreen.tsx
@@ -4,7 +4,7 @@ import { Input } from '../components/ui/Input';
 import { Card, CardHeader, CardContent, CardFooter } from '../components/ui/Card';
 import { Badge } from '../components/ui/Badge';
 import { ArrowLeft, Search, Filter, Star, Heart, MessageCircle, Share, Crown, Zap, Users, TrendingUp, Award, Eye, Bookmark, Play, ChevronDown, Grid3X3, List, SlidersHorizontal, Sparkles, Target, Shield, Rocket, BarChart3, BookOpen, MessageSquare, Verified, Trophy, Flame, Clock, Calendar } from 'lucide-react';
-import { Prompt } from '../types';
+import { Prompt } from '../src/types';
 
 interface CommunityScreenProps {
   onNavigate: (screen: string) => void;

--- a/CreatePromptScreen.tsx
+++ b/CreatePromptScreen.tsx
@@ -4,7 +4,7 @@ import { Input } from '../components/ui/Input';
 import { Card, CardHeader, CardContent, CardFooter } from '../components/ui/Card';
 import { Badge } from '../components/ui/Badge';
 import { ArrowLeft, Save, Play, Zap, AlertCircle, Globe, Lock, Crown } from 'lucide-react';
-import { Variable, User } from '../types';
+import { Variable, User } from '../src/types';
 
 interface CreatePromptScreenProps {
   onNavigate: (screen: string) => void;

--- a/ExecutePromptScreen.tsx
+++ b/ExecutePromptScreen.tsx
@@ -4,7 +4,7 @@ import { Input } from '../components/ui/Input';
 import { Card, CardHeader, CardContent, CardFooter } from '../components/ui/Card';
 import { Badge } from '../components/ui/Badge';
 import { ArrowLeft, Play, Copy, Download, FileText, Save, CheckCircle } from 'lucide-react';
-import { Prompt, Variable } from '../types';
+import { Prompt, Variable } from '../src/types';
 
 interface ExecutePromptScreenProps {
   prompt?: Prompt;

--- a/HomeScreen.tsx
+++ b/HomeScreen.tsx
@@ -3,7 +3,7 @@ import { Button } from '../components/ui/Button';
 import { Card, CardHeader, CardContent, CardFooter } from '../components/ui/Card';
 import { Badge } from '../components/ui/Badge';
 import { Plus, Library, Mail, FileText, Users, Zap, TrendingUp, Clock, Sparkles, ArrowRight, Star, Play, Crown, BarChart3, Target, Layers, Bot, Wand2, Database, ChevronRight, Activity, Award, Briefcase, Settings, Bell, Search, Filter, Grid3X3, List, Eye, Heart, Bookmark, Share2, Download, Copy, Edit3, Trash2, MoreHorizontal, Calendar, User, MessageCircle, Globe, Shield, Rocket, Lightbulb, Cpu, Palette, Code, Headphones, Command, Mic, Maximize2, Minimize2, RotateCcw, Repeat, Workflow, Layers3, Boxes, Gauge, Compass, Flame, Gem, Hexagon, Infinity, Orbit, Radar, Sparkle, Waves, Wind } from 'lucide-react';
-import { User as UserType, Prompt } from '../types';
+import { User as UserType, Prompt } from '../src/types';
 
 interface HomeScreenProps {
   user: UserType;

--- a/LibraryScreen.tsx
+++ b/LibraryScreen.tsx
@@ -4,7 +4,7 @@ import { Input } from '../components/ui/Input';
 import { Card, CardHeader, CardContent } from '../components/ui/Card';
 import { Badge } from '../components/ui/Badge';
 import { Search, Filter, Plus, Star, Users, ArrowLeft, Grid3X3, List, SlidersHorizontal, Sparkles, Clock, TrendingUp, Award, Zap, Target, Briefcase, MessageSquare, BarChart3, BookOpen, Lightbulb, Rocket, Shield, Heart, Eye, Play, ChevronRight, User, Crown } from 'lucide-react';
-import { Prompt, User as UserType } from '../types';
+import { Prompt, User as UserType } from '../src/types';
 
 interface LibraryScreenProps {
   user: UserType;

--- a/MyPromptsScreen.tsx
+++ b/MyPromptsScreen.tsx
@@ -4,7 +4,7 @@ import { Input } from '../components/ui/Input';
 import { Card, CardHeader, CardContent } from '../components/ui/Card';
 import { Badge } from '../components/ui/Badge';
 import { ArrowLeft, Search, Plus, Play, Edit, Trash2, Calendar, Clock } from 'lucide-react';
-import { Prompt, PromptExecution } from '../types';
+import { Prompt, PromptExecution } from '../src/types';
 
 interface MyPromptsScreenProps {
   onNavigate: (screen: string) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,52 @@
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  profession: string;
+  isPro: boolean;
+  promptsUsed: number;
+  promptsLimit: number;
+}
+
+export interface Variable {
+  name: string;
+  example?: string;
+  defaultValue?: string;
+  required?: boolean;
+}
+
+export interface Prompt {
+  id: string;
+  title: string;
+  content: string;
+  profession: string;
+  category: string;
+  tone: string;
+  variables: Variable[];
+  rating?: number;
+  usageCount?: number;
+  createdAt: Date;
+  author?: string;
+  isPersonal?: boolean;
+  isFavorited?: boolean;
+}
+
+export interface AppState {
+  currentScreen: string;
+  user: User | null;
+  selectedPrompt: Prompt | null;
+}
+
+export interface JobDetection {
+  id: string;
+  job: string;
+  confidence: number;
+}
+
+export interface PromptExecution {
+  id: string;
+  promptId: string;
+  variables: Record<string, any>;
+  result: string;
+  createdAt: Date;
+}

--- a/useAuth.ts
+++ b/useAuth.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { User as SupabaseUser } from '@supabase/supabase-js';
 import { supabase } from '../lib/supabase';
-import { User } from '../types';
+import { User } from '../src/types';
 
 export function useAuth() {
   const [user, setUser] = useState<User | null>(null);

--- a/useFlows.ts
+++ b/useFlows.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
-import { Prompt } from '../types';
+import { Prompt } from '../src/types';
 
 interface Flow {
   id: string;


### PR DESCRIPTION
## Summary
- define app-wide interfaces in new `src/types.ts`
- update imports to use shared types module

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685815a19d34832a91bfb7e73ab36333